### PR TITLE
Add delimiter option for CSV

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -121,6 +121,7 @@ function encloser (value: string) {
 export function createCSVData (
   data: any[],
   beforeTableEncode: (entries: ITableEntries) => ITableEntries = i => i,
+  delimiter = "'",
 ) {
   if (!data.length) return ''
 
@@ -129,11 +130,11 @@ export function createCSVData (
 
   // Rule: Columns (fields) are separated by commas.
   // Rule: Rows are separated by line breaks (newline characters).
-  const head = tableEntries.map(({ fieldName }) => fieldName).join(',') + '\r\n'
+  const head = tableEntries.map(({ fieldName }) => fieldName).join(delimiter) + '\r\n'
   const columns = tableEntries.map(({ fieldValues }) => fieldValues)
     .map(column => column.map(encloser))
   const rows = columns.reduce(
-    (mergedColumn, column) => mergedColumn.map((value, rowIndex) => `${value},${column[rowIndex]}`),
+    (mergedColumn, column) => mergedColumn.map((value, rowIndex) => `${value}${delimiter}${column[rowIndex]}`),
   )
 
   return head + rows.join('\r\n')

--- a/src/exportFromJSON.ts
+++ b/src/exportFromJSON.ts
@@ -16,6 +16,7 @@ export interface IOption<R = void> {
   beforeTableEncode?: (
     tableRow: Array<{ fieldName: string, fieldValues: string[] }>,
   ) => Array<{ fieldName: string, fieldValues: string[]}>
+  delimiter?: string
 }
 
 function exportFromJSON<R = void> ({
@@ -30,6 +31,7 @@ function exportFromJSON<R = void> ({
   processor = downloadFile as any,
   withBOM = false,
   beforeTableEncode = (i) => i,
+  delimiter,
 }: IOption<R>): R {
   const MESSAGE_IS_ARRAY_FAIL = 'Invalid export data. Please provide an array of objects'
   const MESSAGE_UNKNOWN_EXPORT_TYPE = `Can't export unknown data type ${exportType}.`
@@ -65,7 +67,7 @@ function exportFromJSON<R = void> ({
     case 'csv': {
       assert(isArray(safeData), MESSAGE_IS_ARRAY_FAIL)
       const BOM = '\ufeff'
-      const CSVData = createCSVData(safeData, beforeTableEncode)
+      const CSVData = createCSVData(safeData, beforeTableEncode, delimiter)
       const content = withBOM ? BOM + CSVData : CSVData
 
       return processor(content, exportType, normalizeFileName(fileName, extension ?? 'csv', fileNameFormatter))


### PR DESCRIPTION
Add delimiter (separator) option for CSV.
Context:

> In a CSV file, data values are separated by a comma (`,`) by convention. However, some software applications (ex: Excel) use a semi-colon (`;`) as the delimiter instead depending on region, which can lead to problems when trying to import or process the data in another application that assumes a comma delimiter.
> 
> The issue is that different regions of the world have different standards for the delimiter used in CSV files. For example, in Europe, it's common to use a semi-colon as the delimiter, while in the US, it's more common to use a comma.
> 
> To resolve this problem, it's important to specify the correct delimiter when exporting the data.

This Pull Request adds an option for choosing the delimiter when working with CSV files:

- The delimiter can now be specified.
- The default delimiter is the comma (`,`).

The new delimiter option provides a flexible solution for users who need to work with CSV files that use different delimiters. This will help avoid any issues with data processing and ensure compatibility with other applications and different regional standards.

I hope you find these changes useful and I look forward to your feedback!