### PR TITLE
Feature/tsv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ http.createServer(function (request, response){
                 case 'csv':
                     response.setHeader('Content-Type', 'text/csv')
                     break
+                case 'tsv':
+                    response.setHeader('Content-Type', 'text/tsv')
+                    break
                 case 'xls':
                     response.setHeader('Content-Type', 'application/vnd.ms-excel')
                     break
@@ -119,18 +122,18 @@ http.createServer(function (request, response){
 
 **Note:** `JSON` refers to a parsable JSON string or a serializable JavaScript object.
 
-| Option name | Required | Type | Description
-| ----------- | -------- | ---- | ----
-| data        | true     | `Array<JSON>`, `JSON` or `string` | If the exportType is 'json', data can be any parsable JSON. If the exportType is 'csv' or 'xls', data can only be an array of parsable JSON.  If the exportType is 'txt', 'css', 'html', the data must be a string type.
-| fileName    | false    | string | filename without extension, default to `'download'`
-| extension    | false    | string | filename extension, by default it takes the exportType
-| fileNameFormatter    | false    | `(name: string) => string` | filename formatter, by default the file name will be formatted to snake case
-| fields      | false    | `string[]` or field name mapper type `Record<string, string>`  | fields filter, also supports mapper field name by passing an name mapper, e.g. { 'bar': 'baz' }, default to `undefined`
-| exportType  | false    | Enum ExportType | 'txt'(default), 'css', 'html', 'json', 'csv', 'xls', 'xml'
-| processor   | false    | `(content: string, type: ExportType, fileName: string) => any` | default to a front-end downloader
-| withBOM     | false    | boolean | Add BOM(byte order mark) meta to CSV file. BOM is expected by `Excel` when reading UTF8 CSV file. It is default to `false`.
-| beforeTableEncode     | false    | `(entries: { fieldName: string, fieldValues: string[] }[]) => { fieldName: string, fieldValues: string[] }[]` | Given a chance to altering table entries, only works for `CSV` and `XLS` file, by default no altering.
-| delimiter   | false    | `',' \| ';'` | Specify CSV raw data's delimiter between values. It is default to `,`
+| Option name | Required | Type                                                                                                          | Description                                                                                                                                                                                                              
+| ----------- | -------- |---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| data        | true     | `Array<JSON>`, `JSON` or `string`                                                                             | If the exportType is 'json', data can be any parsable JSON. If the exportType is 'csv' or 'xls', data can only be an array of parsable JSON.  If the exportType is 'txt', 'css', 'html', the data must be a string type. 
+| fileName    | false    | string                                                                                                        | filename without extension, default to `'download'`                                                                                                                                                                      
+| extension    | false    | string                                                                                                        | filename extension, by default it takes the exportType                                                                                                                                                                   
+| fileNameFormatter    | false    | `(name: string) => string`                                                                                    | filename formatter, by default the file name will be formatted to snake case                                                                                                                                             
+| fields      | false    | `string[]` or field name mapper type `Record<string, string>`                                                 | fields filter, also supports mapper field name by passing an name mapper, e.g. { 'bar': 'baz' }, default to `undefined`                                                                                                  
+| exportType  | false    | Enum ExportType                                                                                               | 'txt'(default), 'css', 'html', 'json', 'csv', 'xls', 'xml', 'tsv'                                                                                                                                                        
+| processor   | false    | `(content: string, type: ExportType, fileName: string) => any`                                                | default to a front-end downloader                                                                                                                                                                                        
+| withBOM     | false    | boolean                                                                                                       | Add BOM(byte order mark) meta to CSV file. BOM is expected by `Excel` when reading UTF8 CSV file. It is default to `false`.                                                                                              
+| beforeTableEncode     | false    | `(entries: { fieldName: string, fieldValues: string[] }[]) => { fieldName: string, fieldValues: string[] }[]` | Given a chance to altering table entries, only works for `CSV` and `XLS` file, by default no altering.                                                                                                                   
+| delimiter   | false    | `',' \| ';' \| '\t'`                                                                                          | Specify CSV/TSV raw data's delimiter between values. It is default to `,`
 
 ### Tips
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -110,8 +110,8 @@ export function _createTableEntries (
 //       (not all programs support values with line breaks).
 // Rule: All other fields do not require double quotes.
 // Rule: Double quotes within values are represented by two contiguous double quotes.
-function encloser (value: string, delimiter: ',' | ';') {
-  const enclosingTester = new RegExp(`${delimiter}|"|\n`)
+function encloser (value: string, delimiter: ',' | ';' | '\t') {
+  const enclosingTester = new RegExp(`${delimiter === "\t" ? "\\t" : delimiter}|"|\n`)
   const enclosingCharacter = enclosingTester.test(value) ? '"' : ''
   const escaped = value.replace(/"/g, '""')
 
@@ -120,7 +120,7 @@ function encloser (value: string, delimiter: ',' | ';') {
 
 interface CreateCSVDataOptions {
   beforeTableEncode?: (entries: ITableEntries) => ITableEntries,
-  delimiter?: ',' | ';',
+  delimiter?: ',' | ';' | "\t",
 }
 
 const defaultCreateCSVDataOption: Required<CreateCSVDataOptions> = { beforeTableEncode: i => i, delimiter: ',' }

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -30,8 +30,9 @@ export function generateDataURI (content: string, type: ExportType, byBlob: bool
 
       return `data:,${blobType}` + encodeURIComponent(content)
     }
+    case "tsv":
     case 'csv': {
-      const blobType = 'text/csv;charset=utf-8'
+      const blobType = `text/${type};charset=utf-8`
 
       if (byBlob) return URL.createObjectURL(new Blob([content], { type: blobType }))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ExportType = 'txt' | 'json' | 'csv' | 'xls' | 'xml' | 'css' | 'html'
+export type ExportType = 'txt' | 'json' | 'csv' | 'xls' | 'xml' | 'css' | 'html' | 'tsv'
 
 export const exportTypes: { [ET in ExportType]: ET } = {
     txt : 'txt',
@@ -8,4 +8,5 @@ export const exportTypes: { [ET in ExportType]: ET } = {
     csv : 'csv',
     xls : 'xls',
     xml : 'xml',
+    tsv : 'tsv'
 }


### PR DESCRIPTION
I noticed that this library does not have support for tsv format, however, the code that exists should be able to handle it already simply by using a different delimiter.

This pull request makes the necessary changes to allow using tsv as the export type.

Currently, when using typescript, you can get tsv exports working by casting the exportFromJSON function to a custom type that allows for "\t" as a delimiter. Adding support directly to the library would be very convenient and prevent the need for ugly type casting.

Note: my IDE added some spacing to the README, and I could not figure out how to prevent it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for tab-separated values (TSV) export, enhancing data export options.
	- Updated documentation to include TSV as a valid export type and delimiter.
  
- **Bug Fixes**
	- Improved handling of delimiters in various functions to support tab characters.
  
- **Documentation**
	- Updated README to reflect new TSV export capabilities and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->